### PR TITLE
build 時にワーニングが出ていたので export 方法を調整した

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ panda.config.ts の presets 部分を以下のように設定します。
 
 ```diff
 import { defineConfig } from "@pandacss/dev";
-+ import { preset } from '@togana/digital-go-jp-panda-preset';
++ import preset from '@togana/digital-go-jp-panda-preset';
 
 export default defineConfig({
   // Whether to use css reset

--- a/examples/next/panda.config.ts
+++ b/examples/next/panda.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "@pandacss/dev";
-import { preset } from '../../packages/digital-go-jp-panda-preset/src/index';
+import preset from '../../packages/digital-go-jp-panda-preset/src/index';
 
 export default defineConfig({
   // Whether to use css reset

--- a/examples/studio/panda.config.ts
+++ b/examples/studio/panda.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "@pandacss/dev";
-import { preset } from '../../packages/digital-go-jp-panda-preset/src/index';
+import preset from '../../packages/digital-go-jp-panda-preset/src/index';
 
 export default defineConfig({
   // Whether to use css reset

--- a/packages/digital-go-jp-panda-preset/README.md
+++ b/packages/digital-go-jp-panda-preset/README.md
@@ -12,7 +12,7 @@ panda.config.ts の presets 部分を以下のように設定します。
 
 ```diff
 import { defineConfig } from "@pandacss/dev";
-+ import { preset } from '@togana/digital-go-jp-panda-preset';
++ import preset from '@togana/digital-go-jp-panda-preset';
 
 export default defineConfig({
   // Whether to use css reset

--- a/packages/digital-go-jp-panda-preset/src/index.ts
+++ b/packages/digital-go-jp-panda-preset/src/index.ts
@@ -15,7 +15,7 @@ import {
 
 const definePreset = <T extends Preset>(config: T) => config;
 
-export const preset = definePreset({
+const preset = definePreset({
   theme: {
     breakpoints: breakpoints,
     tokens: {


### PR DESCRIPTION
warning 内容

```
Entry module "dist/index.js" is using named and default exports together. Consumers of your bundle will have to use `chunk.default` to access the default export, which may not be what you want. Use `output.exports: "named"` to disable this warning.
```