### PR TITLE
github actions での turbo の cache を github actions cache に載せ替えた

### DIFF
--- a/.changeset/metal-tables-behave.md
+++ b/.changeset/metal-tables-behave.md
@@ -1,0 +1,5 @@
+---
+"@togana/digital-go-jp-panda-preset": patch
+---
+
+github actions での turbo の cache を github actions cache に載せ替えた

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -13,10 +13,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Launch Turbo Remote Cache Server
-        uses: rharkor/caching-for-turbo@v1.1
-        with:
-          cache-prefix: turbogha_
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with: 
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
       - run: corepack enable 
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,10 +26,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Launch Turbo Remote Cache Server
-      uses: rharkor/caching-for-turbo@v1.1
-      with:
-        cache-prefix: turbogha_
+    - name: Cache turbo build setup
+      uses: actions/cache@v4
+      with: 
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
     - run: corepack enable 
     - name: Use Node.js
       uses: actions/setup-node@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,10 +28,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Launch Turbo Remote Cache Server
-        uses: rharkor/caching-for-turbo@v1.1
-        with:
-          cache-prefix: turbogha_
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with: 
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
       - run: corepack enable 
       - name: Use Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
https://turbo.build/repo/docs/guides/ci-vendors/github-actions#caching-with-github-actionscache