### PR TITLE
renovate の設定を変更した

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,15 +12,8 @@
     ":labels(renovate)",
     ":timezone(Asia/Tokyo)"
   ],
-  "packageRules": [
-    {
-      "matchFileNames": [
-        "examples/**"
-      ],
-      "matchManagers": [
-        "npm"
-      ]
-    }
+  "ignorePaths": [
+    "**/node_modules/**"
   ],
   "rebaseWhen": "never",
   "schedule": [


### PR DESCRIPTION
config:recommended 内部で examples paths が除外されているみたいなので明示した

https://github.com/renovatebot/renovate/blob/fd5ba4c840ff29b5c07284f444317fc176f7c0bc/lib/config/presets/internal/default.ts#L298